### PR TITLE
docs: add real-time watch data section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,14 @@ class HealthViewModel: ObservableObject {
 }
 ```
 
+## ⌚ Real-Time Watch Data
+
+Due to HealthKit API limitations, real-time biometric streaming (HR, HRV, accelerometer) on Apple Watch requires an active `HKWorkoutSession`. For real-time session-based data, use the Synheart watchOS companion app alongside the [Synheart Session SDK](https://github.com/synheart-ai/synheart-session):
+
+- [synheart-wear-watch-ios](https://github.com/synheart-ai/synheart-wear-watch-ios) — watchOS companion app (HKWorkoutSession, HKLiveWorkoutBuilder, WCSession relay)
+
+This SDK handles non-realtime and historical data (daily HR, HRV, steps, sleep, etc.) which does not require a workout session.
+
 ## 🤝 Contributing
 
 We welcome contributions! See the main repository's [Contributing Guidelines](https://github.com/synheart-ai/synheart-wear/blob/main/CONTRIBUTING.md) for details.


### PR DESCRIPTION
- Introduced a new section detailing the requirements for real-time biometric streaming on Apple Watch using HealthKit API.
- Provided links to the Synheart watchOS companion app and the Synheart Session SDK for session-based and historical data handling.