### PR TITLE
feat(backfill): add HealthHistoryReader contract for historical reads

### DIFF
--- a/Sources/Backfill/HealthHistory.swift
+++ b/Sources/Backfill/HealthHistory.swift
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Historical HealthKit read contract. Consumed by
+// `SynheartCore.Backfill.HealthKitRuntimeSink` in synheart-core-swift
+// to seed the runtime SRM from Apple Health history at install / login.
+//
+// Parallels Flutter's `HealthAdapter.fetchSleepNights` /
+// `fetchOvernightPhysiology` in synheart_wear, and the Kotlin
+// `HealthHistoryReader` in synheart-wear-kotlin's
+// `ai.synheart.wear.backfill` package — wear owns HealthKit SDK calls,
+// core owns aggregation and runtime push.
+
+import Foundation
+
+/// Per-night sleep summary keyed by local wake-day (the day the sleep
+/// session ended in the caller-supplied time zone).
+///
+/// - `totalAsleepMinutes` excludes AWAKE / IN-BED-WITHOUT-SLEEP stages
+///   when stage data is present. Falls back to session duration when
+///   stages are absent.
+/// - `deepMinutes` / `remMinutes` are nil when the source didn't classify
+///   stages (e.g. devices that only emit a sleep session without a
+///   stage breakdown).
+public struct SleepNightSummary: Equatable, Sendable {
+    public let totalAsleepMinutes: Double
+    public let deepMinutes: Double?
+    public let remMinutes: Double?
+
+    public init(totalAsleepMinutes: Double, deepMinutes: Double?, remMinutes: Double?) {
+        self.totalAsleepMinutes = totalAsleepMinutes
+        self.deepMinutes = deepMinutes
+        self.remMinutes = remMinutes
+    }
+}
+
+/// Per-night overnight physiology keyed by local wake-day.
+///
+/// HR and HRV-RMSSD are averaged over the sleep window(s) for that day.
+/// A field is nil when no in-sleep samples were available — the runtime
+/// treats nils as "missing for this day" rather than zero.
+public struct OvernightPhysiologySummary: Equatable, Sendable {
+    public let hrvRmssdMs: Double?
+    public let restingHrBpm: Double?
+
+    public init(hrvRmssdMs: Double?, restingHrBpm: Double?) {
+        self.hrvRmssdMs = hrvRmssdMs
+        self.restingHrBpm = restingHrBpm
+    }
+}
+
+/// Reader contract for historical HealthKit data. Implemented by
+/// `HealthKitHistoryReader`; abstracted so synheart-core-swift can
+/// depend on the shape without importing HealthKit and so tests can
+/// fake the reads.
+///
+/// Both fetch methods bucket by **local wake-day** (the day the sleep
+/// session ended) using the caller-supplied `timeZone`. The key `Date`
+/// represents midnight at the start of that wake-day in the requested
+/// zone. An empty map is a valid "no data" response — callers should
+/// not treat it as an error.
+public protocol HealthHistoryReader: AnyObject, Sendable {
+    /// True when HealthKit is available and the host has been granted
+    /// the read authorizations the reader needs.
+    func isAvailable() async -> Bool
+
+    func fetchSleepNights(
+        start: Date,
+        end: Date,
+        timeZone: TimeZone
+    ) async throws -> [Date: SleepNightSummary]
+
+    func fetchOvernightPhysiology(
+        start: Date,
+        end: Date,
+        timeZone: TimeZone
+    ) async throws -> [Date: OvernightPhysiologySummary]
+}

--- a/Sources/Backfill/HealthKitHistoryReader.swift
+++ b/Sources/Backfill/HealthKitHistoryReader.swift
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// HealthKit-backed `HealthHistoryReader` for iOS / watchOS.
+//
+// Designed to be created once and reused. Owns its own `HKHealthStore`
+// — does not extract HealthKit calls from `SynheartWear`. That keeps
+// the backfill path self-contained and lets apps use it without
+// initializing the full `SynheartWear` machinery.
+//
+// Authorization is the caller's responsibility: request read access
+// to `.heartRate`, `.heartRateVariabilitySDNN`, and `.sleepAnalysis`
+// up-front. The reader's `isAvailable()` returns true when HealthKit
+// itself is available; per-type authorization is checked at read time
+// (HealthKit returns empty results without throwing when read access
+// is denied — by design, to avoid leaking presence/absence of data).
+
+#if canImport(HealthKit)
+import Foundation
+import HealthKit
+
+public final class HealthKitHistoryReader: HealthHistoryReader, @unchecked Sendable {
+
+    private let healthStore: HKHealthStore
+
+    public init(healthStore: HKHealthStore = HKHealthStore()) {
+        self.healthStore = healthStore
+    }
+
+    public func isAvailable() async -> Bool {
+        return HKHealthStore.isHealthDataAvailable()
+    }
+
+    // ────────────────────────────────────────────────────────────── //
+    // Sleep                                                           //
+    // ────────────────────────────────────────────────────────────── //
+
+    public func fetchSleepNights(
+        start: Date,
+        end: Date,
+        timeZone: TimeZone
+    ) async throws -> [Date: SleepNightSummary] {
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            return [:]
+        }
+
+        let samples = try await categorySamples(
+            type: sleepType,
+            start: start,
+            end: end
+        )
+        if samples.isEmpty { return [:] }
+
+        var byDay: [Date: (asleep: Double, deep: Double?, rem: Double?)] = [:]
+        for sample in samples {
+            let mins = sample.endDate.timeIntervalSince(sample.startDate) / 60.0
+            let wakeDay = startOfDay(for: sample.endDate, in: timeZone)
+
+            var bucket = byDay[wakeDay] ?? (asleep: 0.0, deep: nil, rem: nil)
+            switch sample.value {
+            // Awake / in-bed-without-sleep buckets do not count toward asleep.
+            case HKCategoryValueSleepAnalysis.awake.rawValue,
+                 HKCategoryValueSleepAnalysis.inBed.rawValue:
+                break
+            case HKCategoryValueSleepAnalysis.asleepDeep.rawValue:
+                bucket.asleep += mins
+                bucket.deep = (bucket.deep ?? 0.0) + mins
+            case HKCategoryValueSleepAnalysis.asleepREM.rawValue:
+                bucket.asleep += mins
+                bucket.rem = (bucket.rem ?? 0.0) + mins
+            default:
+                // asleepCore, asleepUnspecified, plus legacy `.asleep` (iOS 15
+                // and earlier) all count toward asleep without contributing
+                // to a stage bucket.
+                bucket.asleep += mins
+            }
+            byDay[wakeDay] = bucket
+        }
+
+        return byDay.mapValues { b in
+            SleepNightSummary(
+                totalAsleepMinutes: b.asleep,
+                deepMinutes: b.deep,
+                remMinutes: b.rem
+            )
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────── //
+    // Overnight HR + HRV                                              //
+    // ────────────────────────────────────────────────────────────── //
+
+    public func fetchOvernightPhysiology(
+        start: Date,
+        end: Date,
+        timeZone: TimeZone
+    ) async throws -> [Date: OvernightPhysiologySummary] {
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis),
+              let hrType = HKQuantityType.quantityType(forIdentifier: .heartRate),
+              let hrvType = HKQuantityType.quantityType(forIdentifier: .heartRateVariabilitySDNN) else {
+            return [:]
+        }
+
+        let sleepSamples = try await categorySamples(type: sleepType, start: start, end: end)
+        if sleepSamples.isEmpty { return [:] }
+
+        // Restrict to actual-asleep windows (matches Flutter / Kotlin
+        // "overnight only" semantic — in-bed-while-awake samples
+        // shouldn't pull the average down).
+        let asleepWindows = sleepSamples.filter { sample in
+            switch sample.value {
+            case HKCategoryValueSleepAnalysis.awake.rawValue,
+                 HKCategoryValueSleepAnalysis.inBed.rawValue:
+                return false
+            default:
+                return true
+            }
+        }
+        if asleepWindows.isEmpty { return [:] }
+
+        async let hrSamples = quantitySamples(type: hrType, start: start, end: end)
+        async let hrvSamples = quantitySamples(type: hrvType, start: start, end: end)
+        let hrPerMinute = HKUnit.count().unitDivided(by: HKUnit.minute())
+        let ms = HKUnit.secondUnit(with: .milli)
+
+        let hrPoints: [(Date, Double)] = try await hrSamples.map {
+            ($0.startDate, $0.quantity.doubleValue(for: hrPerMinute))
+        }
+        let hrvPoints: [(Date, Double)] = try await hrvSamples.map {
+            ($0.startDate, $0.quantity.doubleValue(for: ms))
+        }
+
+        var byDay: [Date: (hrSum: Double, hrN: Int, hrvSum: Double, hrvN: Int)] = [:]
+        for window in asleepWindows {
+            let wakeDay = startOfDay(for: window.endDate, in: timeZone)
+            var acc = byDay[wakeDay] ?? (0.0, 0, 0.0, 0)
+            for (t, bpm) in hrPoints where t >= window.startDate && t < window.endDate {
+                acc.hrSum += bpm; acc.hrN += 1
+            }
+            for (t, rmssd) in hrvPoints where t >= window.startDate && t < window.endDate {
+                acc.hrvSum += rmssd; acc.hrvN += 1
+            }
+            byDay[wakeDay] = acc
+        }
+
+        return byDay.mapValues { a in
+            OvernightPhysiologySummary(
+                hrvRmssdMs: a.hrvN > 0 ? a.hrvSum / Double(a.hrvN) : nil,
+                restingHrBpm: a.hrN > 0 ? a.hrSum / Double(a.hrN) : nil
+            )
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────── //
+    // HealthKit query helpers                                         //
+    // ────────────────────────────────────────────────────────────── //
+
+    private func categorySamples(
+        type: HKCategoryType,
+        start: Date,
+        end: Date
+    ) async throws -> [HKCategorySample] {
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        return try await withCheckedThrowingContinuation { cont in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil
+            ) { _, samples, error in
+                if let error = error { cont.resume(throwing: error); return }
+                cont.resume(returning: (samples as? [HKCategorySample]) ?? [])
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    private func quantitySamples(
+        type: HKQuantityType,
+        start: Date,
+        end: Date
+    ) async throws -> [HKQuantitySample] {
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        return try await withCheckedThrowingContinuation { cont in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil
+            ) { _, samples, error in
+                if let error = error { cont.resume(throwing: error); return }
+                cont.resume(returning: (samples as? [HKQuantitySample]) ?? [])
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    private func startOfDay(for date: Date, in timeZone: TimeZone) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        return cal.startOfDay(for: date)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- New \`Sources/Backfill/\` directory: \`HealthHistory.swift\` (protocol + value types) and \`HealthKitHistoryReader.swift\` (HealthKit-backed impl).
- \`HealthHistoryReader\` protocol mirrors the Kotlin/Flutter shape — \`fetchSleepNights\` and \`fetchOvernightPhysiology\` return per-local-wake-day summaries.
- \`HealthKitHistoryReader\` owns its own \`HKHealthStore\`, buckets sleep sessions by local wake-day with stage-aware aggregation (DEEP/REM tracked, AWAKE / IN-BED-WITHOUT-SLEEP excluded; falls back to session duration when stages are absent), and averages in-sleep HR / HRV-RMSSD per night.

## Why
Consumed by \`synheart-core-swift\`'s new \`HealthKitRuntimeSink\` for SRM cold-start backfill at install / login. Wear owns HealthKit SDK calls; core stays HealthKit-agnostic — same separation as Kotlin (\`synheart-wear-kotlin#17\`) and Flutter.

## Notes
- Authorization is the caller's responsibility (request read access to \`.heartRate\`, \`.heartRateVariabilitySDNN\`, \`.sleepAnalysis\` up-front).
- HealthKit-only — wrapped in \`#if canImport(HealthKit)\` for non-Apple platforms.
- \`@_exported\` not used — consumers \`import SynheartWear\` and get the protocol via the umbrella.

## Test plan
- [x] \`swift build\` passes (no errors; existing protobuf deprecation warnings only)
- [ ] CI green
- [ ] Manual: HealthKit-authorised app on iOS confirms \`fetchSleepNights\` per-day stage minutes and \`fetchOvernightPhysiology\` HR / HRV averages over the sleep window