### PR TITLE
ci(close-external-prs): never auto-close bot PRs (Dependabot/Renovate)

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -24,6 +24,13 @@ jobs:
             const login = pr.user.login;
             const association = pr.author_association;
 
+            // Never close automation PRs (Dependabot, Renovate, etc.). They are
+            // first-party maintenance, not external contributions.
+            if (login.endsWith("[bot]")) {
+              core.info(`Skipping bot author @${login}`);
+              return;
+            }
+
             // Trust the webhook payload when it already reports a member-like
             // association. Note: for users with PRIVATE org membership, this
             // field can arrive as NONE/CONTRIBUTOR even though the org API


### PR DESCRIPTION
The `close-external-prs` workflow classifies any non-member PR author as external and closes the PR. Bot accounts (Dependabot, Renovate) are not org members, so their dependency-update PRs were being auto-closed.

This adds an early skip for `*[bot]` authors so automation PRs are left open.

One-line behavioral change; matches the carve-out already in `syni-*` and `synheart-sensor-agent`.